### PR TITLE
Fix bug in run-app.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To see how to run the script run ```./run-app.sh``` or ```./run-app.sh -h``` on 
 If you leave the script file in the same directory as on this repository, then simply run ```./run-app.sh -p .```.
 
 After runnining the script for the first time, which might take a few minutes due to the installations, you can comment out
-lines [42](https://github.com/dimosp/CineFriends/blob/main/run-app.sh#L42) and [55](https://github.com/dimosp/CineFriends/blob/main/run-app.sh#L55) of [run-app.sh](https://github.com/dimosp/CineFriends/blob/main/run-app.sh), which have the ```npm install``` command.
+lines [42](https://github.com/dimosp/CineFriends/blob/main/run-app.sh#L42) and [56](https://github.com/dimosp/CineFriends/blob/main/run-app.sh#L56) of [run-app.sh](https://github.com/dimosp/CineFriends/blob/main/run-app.sh), which have the ```npm install``` command.
 
 
 ## Contributing

--- a/run-app.sh
+++ b/run-app.sh
@@ -51,10 +51,12 @@ while getopts ":hp:" option; do
 		 # focus back to the user in a Linux terminal.
 		 
 		 # Install frontend dependencies (this migth take a few minutes)
-		 cd $frontend_package_path
+		 cd ..
+       cd $frontend_package_path
 		 npm install &				# comment this line if you have everything installed
 		 # Run React.js app
 		 # Accesible from http://localhost:3000
+       cd ..
 		 cd $frontend_app_path
 		 npm start
 		 


### PR DESCRIPTION
The script did not function as it was
supposed to when given as path arguement
the current directory with ".".

Also, updated the README.md concerning the
lines that are supposed to be commented out
if installations are already done.