### PR TITLE
Fix navbar appearing in Landing Page

### DIFF
--- a/frontend/src/core/Menu.js
+++ b/frontend/src/core/Menu.js
@@ -41,7 +41,7 @@ function Menu({ history }) {
     }, [searchTerm]);
 
     
-    if (!isAuthenticated() && history.location.pathname === "/"){
+    if (history.location.pathname === "/"){
         return (            
                 <p class="mt-5 mb-3 text-muted fixed-bottom" align="center"><a href="https://github.com/dimosp/CineFriends">SKG.CODE Binge</a> &copy; 2020-2021</p>        
         );

--- a/frontend/src/post/Post.js
+++ b/frontend/src/post/Post.js
@@ -246,12 +246,13 @@ class SinglePost extends Component {
                         <i className="fa fa-gittip"></i> 
                     {likes} {likeIcon()}
                 </a>
+                <Link to={`/post/${this.props.posterId}`} >
                 <a 
                     href="#" 
                     className="card-link p-2 text-dark">
                         <i className="fa fa-comment"></i> 
                     {comments} {`Comments`}
-                </a>
+                </a></Link>
                 {/* <a 
                     href="#" 
                     className="card-link p-2">


### PR DESCRIPTION
The navbar used to appear in the landing page
when the user was still signed in, this was fixed.

Also, the comment counter is now clickable and links
to the post with the comment section.